### PR TITLE
skip_premap bug fix (closes #28), other QC issues when categories missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .nextflow*
 results*
+work

--- a/assets/multiqc_config.yaml
+++ b/assets/multiqc_config.yaml
@@ -64,7 +64,7 @@ custom_data:
         plot_type: 'bargraph'
         pconfig:
             id: 'duplexes'
-        
+
 custom_plot_config:
     intrainter:
         intergenic:

--- a/bin/tosca_qc.R
+++ b/bin/tosca_qc.R
@@ -2,23 +2,52 @@
 suppressPackageStartupMessages(library(data.table))
 
 # ==========
-# Get hybrid identificaiton metrics
+# Get hybrid identification metrics
 # ==========
 
 message("Getting hybrid identification metrics...")
 
-# Get input and spliced reads
+# Get input and spliced or trimmed reads
 premap.logs <- list.files(".", pattern = "filter_spliced_reads.log$", full.names = TRUE)
-premap.dt <- lapply(seq_along(premap.logs), function(i) {
+if (length(premap.logs) == 0) {
+  message("No premap log files found (pre-mapping was skipped). Using cutadapt logs to get read counts.")
+  # Extract sample names and trimmed read counts from cutadapt logs if available
+  cutadapt.logs <- list.files(".", pattern = ".cutadapt.log$", full.names = TRUE)
+  if (length(cutadapt.logs) > 0) {
+    sample_names <- sapply(basename(cutadapt.logs), function(x) strsplit(x, "\\.")[[1]][1])
 
-  dt <- fread(premap.logs[i], select = 3)
-  pm.dt <- data.table(sample = tstrsplit(basename(premap.logs[i]), "\\.")[[1]],
-                      total = dt[1]$V3,
-                      unspliced = dt[2]$V3,
-                      spliced = dt[3]$V3)
+    # Extract the "Reads written (passing filters)" value from each log file
+    read_counts <- sapply(cutadapt.logs, function(x) {
+      # Find the line containing the number of trimmed reads
+      target_line <- grep("Reads written \\(passing filters\\):", readLines(x), value = TRUE)
+      as.numeric(sub(".*Reads written \\(passing filters\\):\\s*([0-9]+).*", "\\1", target_line))
+  })
+    premap.dt <- data.table(sample = sample_names,
+                            total = read_counts,
+                            unspliced = read_counts,
+                            spliced = 0L)
 
-})
-premap.dt <- rbindlist(premap.dt)
+  } else {
+    sample_names <- character()
+
+    premap.dt <- data.table(sample = sample_names,
+                            total = 0L,
+                            unspliced = 0L,
+                            spliced = 0L)
+  }
+
+} else {
+  premap.dt <- lapply(seq_along(premap.logs), function(i) {
+    dt <- fread(premap.logs[i], select = 3)
+    data.table(
+      sample = tstrsplit(basename(premap.logs[i]), "\\.")[[1]],
+      total = dt[1]$V3,
+      unspliced = dt[2]$V3,
+      spliced = dt[3]$V3
+    )
+  })
+  premap.dt <- rbindlist(premap.dt)
+}
 
 # Get hybrid breakdown
 hybrids.files <- list.files(".", pattern = ".hybrids.tsv.gz$", full.names = TRUE)
@@ -31,11 +60,25 @@ hybrid_identification.dt <- lapply(seq_along(hybrids.files), function(i) {
 
 })
 
-hybrid_identification.dt <- Reduce(function(x, y) merge(x, y, by = "hybrid_selection", all = TRUE), hybrid_identification.dt)
+# Merge the hybrid identification data and premap data
+hybrid_identification.dt <- Reduce(function(x, y) merge(x, y, by = "hybrid_selection", all = TRUE),
+                                   hybrid_identification.dt)
 hybrid_identification.dt <- transpose(hybrid_identification.dt, keep.names = "sample", make.names = "hybrid_selection")
-hybrid_identification.dt <- merge(hybrid_identification.dt, premap.dt, by = "sample")
-hybrid_identification.dt[is.na(hybrid_identification.dt)] <- 0 # Replace any NAs e.g. no multioverlap
+hybrid_identification.dt <- merge(hybrid_identification.dt, premap.dt, by = "sample", all.x = TRUE)
+hybrid_identification.dt[is.na(hybrid_identification.dt)] <- 0  # Replace any NAs
+
+# Ensure the required columns exist; if not, add them with default 0
+hybrid_selection.cols <- c("ambiguous", "multi_overlap", "single")
+for (col in hybrid_selection.cols) {
+  if (!col %in% names(hybrid_identification.dt)) {
+    hybrid_identification.dt[, (col) := 0]
+  }
+}
+
+# Calculate nonhybrid as unspliced minus the sum of hybrid categories
 hybrid_identification.dt[, nonhybrid := unspliced - ambiguous - multi_overlap - single]
+
+# Select final columns
 hybrid_identification.dt <- hybrid_identification.dt[, .(sample, spliced, nonhybrid, ambiguous, multi_overlap, single)]
 
 stopifnot(all(rowSums(hybrid_identification.dt[, -1]) %in% premap.dt$total)) # order might be different
@@ -104,8 +147,14 @@ links.dt[L_region %in% mRNA & R_region == "rRNA", link := "rRNA-mRNA"]
 links.dt[L_region == "rRNA" & R_region %in% mRNA, link := "rRNA-mRNA"]
 links.dt[is.na(link), link := "other"]
 links.dt <- links.dt[, .N, by = .(sample, link)]
-
+# Reshaping to wide format
 links.dt <-  dcast.data.table(links.dt, sample ~ link, value.var = "N")
+
+# Set column order
+links.cols <- c("sample", "rRNA-rRNA", "rRNA-mRNA", "mRNA-mRNA", "other") # all possible column names
+missing.cols <- setdiff(links.cols, names(links.dt))
+lapply(missing.cols, function(col) links.dt[, (col) := 0L]) # assign 0 counts to missing categories
+
 links.dt <- links.dt[, .(sample, `rRNA-rRNA`, `rRNA-mRNA`, `mRNA-mRNA`, other)]
 
 fwrite(links.dt, "links.tsv", sep = "\t")
@@ -125,6 +174,9 @@ intragenic_regions.dt <- rbindlist(list(intragenic_regions.dt[, .(sample, L_regi
                         use.names = FALSE)
 intragenic_regions.dt <- intragenic_regions.dt[, .N, by = .(sample, L_region)]
 
+message(nrow(intragenic_regions.dt))
+
+
 if(!all(regions %in% intragenic_regions.dt$L_region)) {
   missing.dt <- data.table(sample = unique(intragenic_regions.dt$sample),
                            L_region = rep(regions[!regions %in% intragenic_regions.dt$L_region],
@@ -134,7 +186,7 @@ if(!all(regions %in% intragenic_regions.dt$L_region)) {
   intragenic_regions.dt <- rbindlist(list(intragenic_regions.dt, missing.dt))
 }
 
-intragenic_regions.dt <-  dcast.data.table(intragenic_regions.dt, sample ~ L_region, value.var = "N")
+intragenic_regions.dt <-  dcast.data.table(intragenic_regions.dt, sample ~ L_region, value.var = "N", fun.aggregate = sum)
 intragenic_regions.dt <- intragenic_regions.dt[, .(sample, ncRNA, UTR5, CDS, intron, UTR3)]
 
 fwrite(intragenic_regions.dt, "intragenic_regions.tsv", sep = "\t")

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -35,16 +35,16 @@ params {
     min_score = 15
 
     // Hybrid identification
-    split_size = 100000 
+    split_size = 100000
     evalue = 0.001
     maxhits = 100
 
     // Hybrid processing
     umi_separator = '_'
-    dedup_method = 'directional' 
+    dedup_method = 'directional'
     chunk_number = 100
-    cluster_old = false  
-    slurm = false 
+    cluster_old = false
+    slurm = false
     analyse_structures = false
     clusters_only = true
     shuffled_energies = false

--- a/conf/test.config
+++ b/conf/test.config
@@ -26,10 +26,9 @@ params {
   config_profile_description = 'Minimal test dataset to check pipeline function'
 
   // Parameters
-  umi_separator = '_' 
+  umi_separator = '_'
   percent_overlap =  0.5
   chunk_number = 1
-  skip_qc = true
   skip_premap = true
   skip_atlas = true
 

--- a/main.nf
+++ b/main.nf
@@ -35,9 +35,9 @@ if(params.org && params.genomesdir) {
 
 } else {
 
-    if(!params.genome_fai) { exit 1, "--genome_fai is not specified." } 
-    if(!params.transcript_gtf) { exit 1, "--transcript_gtf is not specified." } 
-    if(!params.regions_gtf) { exit 1, "--regions_gtf is not specified." } 
+    if(!params.genome_fai) { exit 1, "--genome_fai is not specified." }
+    if(!params.transcript_gtf) { exit 1, "--transcript_gtf is not specified." }
+    if(!params.regions_gtf) { exit 1, "--regions_gtf is not specified." }
 
 }
 
@@ -58,8 +58,8 @@ if(!params.atlas) {
 
     } else {
 
-        if(!params.transcript_fa) { exit 1, "--transcript_fa is not specified." } 
-        if(!params.transcript_fai) { exit 1, "--transcript_fai is not specified." } 
+        if(!params.transcript_fa) { exit 1, "--transcript_fa is not specified." }
+        if(!params.transcript_fai) { exit 1, "--transcript_fai is not specified." }
 
     }
 
@@ -76,7 +76,7 @@ if(!params.atlas) {
     }
 
     if(params.goi) {
-        ch_goi = Channel.fromPath(params.goi, checkIfExists: true) 
+        ch_goi = Channel.fromPath(params.goi, checkIfExists: true)
     } else {
         ch_goi = Channel.empty()
     }
@@ -106,9 +106,9 @@ log.info "-\033[2m--------------------------------------------------------------
 
 def settings = [:]
 settings['Organism'] = params.org
-if(params.skip_qc) { settings['Skip QC'] = params.skip_qc } 
+if(params.skip_qc) { settings['Skip QC'] = params.skip_qc }
 // if(params.skip_atlas) { settings['Skip atlas generation'] = params.skip_atlas }
-if(params.skip_premap) { settings['Skip premapping'] = params.skip_premap } 
+if(params.skip_premap) { settings['Skip premapping'] = params.skip_premap }
 settings['Adapter sequence'] = params.adapter
 settings['Minimum read quality'] = params.min_quality
 settings['Minimum read length'] = params.min_readlength
@@ -126,8 +126,8 @@ if(params.analyse_structures) settings['Analyse clusters only'] = params.cluster
 if(params.analyse_structures) settings['Analyse shuffled energies'] = params.shuffled_energies
 
 if(params.goi) { settings['Genes of interest'] = params.goi }
-if(params.goi) { settings['Bin size for contact maps'] = params.bin_size } 
-if(params.goi) { settings['Breaks for arcs'] = params.breaks } 
+if(params.goi) { settings['Bin size for contact maps'] = params.bin_size }
+if(params.goi) { settings['Breaks for arcs'] = params.breaks }
 log.info settings.collect { k,v -> "${k.padRight(25)}: $v" }.join("\n")
 log.info "-----------------------------------------------------------------"
 
@@ -147,49 +147,57 @@ workflow {
 
     } else {
 
-        /* 
+        /*
         PREPARE INPUTS
         */
-        METADATA(params.input) // Get fastq paths 
+        METADATA(params.input) // Get fastq paths
         CUTADAPT(METADATA.out) // Trim adapters
 
-        /* 
+        /*
         IDENTIFY HYBRIDS
         */
-        if(!params.skip_premap) {
-            PREMAP(CUTADAPT.out.fastq, ch_star_genome) // Filter spliced reads
-            GET_HYBRIDS(PREMAP.out.fastq, ch_transcript_fa) // Identify hybrids
-        } else {
-            GET_HYBRIDS(CUTADAPT.out.fastq, ch_transcript_fa) // Identify hybrids
-        }
+        ch_for_hybrids = params.skip_premap
+            ? CUTADAPT.out.fastq
+            : PREMAP(CUTADAPT.out.fastq, ch_star_genome).fastq
 
-        /* 
+        GET_HYBRIDS(ch_for_hybrids, ch_transcript_fa) // Identify hybrids
+
+        /*
         IDENTIFY NON-HYBRIDS
         */
         GET_NON_HYBRIDS(GET_HYBRIDS.out.hybrids.join(METADATA.out))
 
-        /* 
+        /*
         PROCESS HYBRIDS
         */
         PROCESS_HYBRIDS(GET_HYBRIDS.out.hybrids, ch_transcript_fa, ch_transcript_gtf, ch_regions_gtf)
 
-        // /* 
+        // /*
         // GET ATLAS
         // */
         // if(!params.skip_atlas) {
         //     GET_ATLAS(PROCESS_HYBRIDS.out.hybrids, ch_transcript_gtf, ch_regions_gtf, ch_genome_fai)
         // }
 
-        /* 
+        /*
         GET VISUALISATIONS
         */
         GET_VISUALISATIONS(PROCESS_HYBRIDS.out.hybrids, PROCESS_HYBRIDS.out.clusters, ch_genome_fai, ch_transcript_fai, ch_goi)
 
-        /* 
+        /*
         MAKE REPORT
         */
         if(!params.skip_qc) {
-            MAKE_REPORT(PREMAP.out.logs.collect(), GET_HYBRIDS.out.logs.collect(), GET_HYBRIDS.out.raw_hybrids.collect{it[1]}, PROCESS_HYBRIDS.out.hybrids.collect{it[1]}, PROCESS_HYBRIDS.out.clusters.collect{it[1]}, ch_multiqc_config)
+            // ch_premap_logs = params.skip_premap ? Channel.empty() : PREMAP.out.logs.collect()
+            // ch_premap_logs = params.skip_premap ? Channel.of([]) : PREMAP.out.logs.collect()
+            ch_input_logs = params.skip_premap ? CUTADAPT.out.log.collect() : PREMAP.out.logs.collect()
+
+            MAKE_REPORT(ch_input_logs,
+                        GET_HYBRIDS.out.logs.collect(),
+                        GET_HYBRIDS.out.raw_hybrids.collect{it[1]},
+                        PROCESS_HYBRIDS.out.hybrids.collect{it[1]},
+                        PROCESS_HYBRIDS.out.clusters.collect{it[1]},
+                        ch_multiqc_config)
         }
 
     }

--- a/modules/cutadapt.nf
+++ b/modules/cutadapt.nf
@@ -7,7 +7,7 @@ process CUTADAPT {
 
     tag "${sample_id}"
     label 'process_medium'
-    // publishDir "${params.outdir}/trimmed", mode: 'copy', overwrite: true
+    publishDir "${params.outdir}/trimmed", mode: 'copy', overwrite: true, pattern: '*.log'
 
     input:
         tuple val(sample_id), path(reads)
@@ -18,7 +18,7 @@ process CUTADAPT {
 
     script:
     args = " -j ${task.cpus}"
-    args += " -a " + params.adapter 
+    args += " -a " + params.adapter
     args += " -q " + params.min_quality
     args += " --minimum-length " + params.min_readlength
     args += " -o ${sample_id}.trimmed.fastq.gz"
@@ -26,5 +26,5 @@ process CUTADAPT {
     """
     cutadapt $args $reads > ${sample_id}.cutadapt.log
     """
-    
+
 }

--- a/modules/multiqc.nf
+++ b/modules/multiqc.nf
@@ -13,7 +13,7 @@ process TOSCA_QC {
     publishDir "${params.outdir}/multiqc", mode: 'copy', overwrite: true
 
     input:
-    path(filter_spliced_reads_logs)
+    path(input_reads_logs)
     path(dedup_logs)
     path(raw_hybrids)
     path(hybrids)


### PR DESCRIPTION
- closes #28; solution: when `skip_premap` is set to false, and no premap logs are produced, the cutadapt logs are loaded instead to be able to calculate the number of trimmed reads; these then are used to compute the number of nonhybrid reads reported in multiQC
- fixed issues in `tosca_qc.R` that gave errors when categories were missing from the hybrid table, such as rRNA regions, or ambiguous hybrids - missing categories are now introduced in the tables with counts of 0.
