### PR TITLE
Added BEDPE outputs

### DIFF
--- a/modules/getvisualisations.nf
+++ b/modules/getvisualisations.nf
@@ -132,7 +132,7 @@ process EXPORT_BEDPE {
         bedpe.colnames <- c("L_seqnames", "L_start", "L_end", "R_seqnames", "R_start", "R_end", "name", "total_count", "L_strand", "R_strand")
         bedpe.dt <- hybrids.dt[, ..bedpe.colnames]
     } else if("$type" == "clusters") {
-        bedpe.colnames <- c("L_seqnames", "L_start", "L_end", "R_seqnames", "R_start", "R_end", "name", "cluster_count", "L_strand", "R_strand")
+        bedpe.colnames <- c("L_seqnames", "L_start", "L_end", "R_seqnames", "R_start", "R_end", "name", "count", "L_strand", "R_strand")
         bedpe.dt <- hybrids.dt[, ..bedpe.colnames]
     }
 

--- a/modules/getvisualisations.nf
+++ b/modules/getvisualisations.nf
@@ -132,7 +132,7 @@ process EXPORT_BEDPE {
         bedpe.colnames <- c("L_seqnames", "L_start", "L_end", "R_seqnames", "R_start", "R_end", "name", "total_count", "L_strand", "R_strand")
         bedpe.dt <- hybrids.dt[, ..bedpe.colnames]
     } else if("$type" == "clusters") {
-        bedpe.colnames <- c("L_seqnames", "L_start", "L_end", "R_seqnames", "R_start", "R_end", "name", "cluster_hybrid_count", "L_strand", "R_strand")
+        bedpe.colnames <- c("L_seqnames", "L_start", "L_end", "R_seqnames", "R_start", "R_end", "name", "cluster_count", "L_strand", "R_strand")
         bedpe.dt <- hybrids.dt[, ..bedpe.colnames]
     }
 

--- a/modules/getvisualisations.nf
+++ b/modules/getvisualisations.nf
@@ -128,7 +128,7 @@ process EXPORT_BEDPE {
     hybrids.dt <- fread("$hybrids")
     hybrids.dt <- toscatools::reorient_hybrids(hybrids.dt)
 
-    if($type == "hybrids") {
+    if("$type" == "hybrids") {
         bedpe.colnames <- c("L_seqnames", "L_start", "L_end", "R_seqnames", "R_start", "R_end", "name", "total_count", "L_strand", "R_strand")
         bedpe.dt <- hybrids.dt[, ..bedpe.colnames]
     } else if($type == "clusters") {

--- a/modules/getvisualisations.nf
+++ b/modules/getvisualisations.nf
@@ -103,3 +103,43 @@ process GET_ARCS {
     """
 
 }
+
+process EXPORT_BEDPE {
+
+    tag "${sample_id}"
+    label 'process_low'
+
+    publishDir "${params.outdir}/igv", mode: 'copy', overwrite: true
+
+    input:
+        val(type)
+        tuple val(sample_id), path(hybrids)
+
+    output:
+        tuple val(sample_id), path("${sample_id}.${type}.bedpe.gz"), emit: bedpe
+
+    script:
+    """
+    #!/usr/bin/env Rscript
+
+    suppressPackageStartupMessages(library(data.table))
+    suppressPackageStartupMessages(library(toscatools))
+
+    hybrids.dt <- fread("$hybrids")
+    hybrids.dt <- toscatools::reorient_hybrids(hybrids.dt)
+
+    if($type == "hybrids") {
+        bedpe.colnames <- c("L_seqnames", "L_start", "L_end", "R_seqnames", "R_start", "R_end", "name", "total_count", "L_strand", "R_strand")
+        bedpe.dt <- hybrids.dt[, ..bedpe.colnames]
+    } else if($type == "clusters") {
+        bedpe.colnames <- c("L_seqnames", "L_start", "L_end", "R_seqnames", "R_start", "R_end", "name", "cluster_hybrid_count", "L_strand", "R_strand")
+        bedpe.dt <- hybrids.dt[, ..bedpe.colnames]
+    }
+
+    bedpe.dt[, `:=` (L_start = L_start - 1, 
+                     R_start = R_start - 1)]
+
+    fwrite(bedpe.dt, "${sample_id}.${type}.bedpe.gz", sep = "\t", col.names = FALSE, quote = FALSE)
+    """
+
+}

--- a/modules/getvisualisations.nf
+++ b/modules/getvisualisations.nf
@@ -131,7 +131,7 @@ process EXPORT_BEDPE {
     if("$type" == "hybrids") {
         bedpe.colnames <- c("L_seqnames", "L_start", "L_end", "R_seqnames", "R_start", "R_end", "name", "total_count", "L_strand", "R_strand")
         bedpe.dt <- hybrids.dt[, ..bedpe.colnames]
-    } else if($type == "clusters") {
+    } else if("$type" == "clusters") {
         bedpe.colnames <- c("L_seqnames", "L_start", "L_end", "R_seqnames", "R_start", "R_end", "name", "cluster_hybrid_count", "L_strand", "R_strand")
         bedpe.dt <- hybrids.dt[, ..bedpe.colnames]
     }

--- a/workflows/getvisualisations.nf
+++ b/workflows/getvisualisations.nf
@@ -23,7 +23,7 @@ workflow GET_VISUALISATIONS {
 
     main:
         EXPORT_HYBRIDS_GENOMIC_BED("hybrids", hybrids)
-        EXPORT_GENOMIC_BAM(EXPORT_HYBRID_GENOMIC_BED.out.bed, genome_fai.collect())
+        EXPORT_GENOMIC_BAM(EXPORT_HYBRIDS_GENOMIC_BED.out.bed, genome_fai.collect())
         EXPORT_CLUSTERS_GENOMIC_BED("clusters", clusters)
 
         EXPORT_HYBRIDS_BEDPE("hybrids", hybrids)

--- a/workflows/getvisualisations.nf
+++ b/workflows/getvisualisations.nf
@@ -3,9 +3,11 @@
 // Specify DSL2
 nextflow.enable.dsl=2
 
-include { EXPORT_GENOMIC_BED as EXPORT_HYBRID_GENOMIC_BED; 
+include { EXPORT_GENOMIC_BED as EXPORT_HYBRIDS_GENOMIC_BED; 
           EXPORT_GENOMIC_BED as EXPORT_CLUSTERS_GENOMIC_BED;
           EXPORT_GENOMIC_BAM;
+          EXPORT_BEDPE as EXPORT_HYBRIDS_BEDPE;
+          EXPORT_BEDPE as EXPORT_CLUSTERS_BEDPE;
           GET_CONTACT_MAPS;
           GET_ARCS } from '../modules/getvisualisations.nf'
 
@@ -20,9 +22,12 @@ workflow GET_VISUALISATIONS {
         goi
 
     main:
-        EXPORT_HYBRID_GENOMIC_BED("hybrids", hybrids)
+        EXPORT_HYBRIDS_GENOMIC_BED("hybrids", hybrids)
         EXPORT_GENOMIC_BAM(EXPORT_HYBRID_GENOMIC_BED.out.bed, genome_fai.collect())
         EXPORT_CLUSTERS_GENOMIC_BED("clusters", clusters)
+
+        EXPORT_HYBRIDS_BEDPE("hybrids", hybrids)
+        EXPORT_CLUSTERS_BEDPE("clusters", clusters)
 
         if(params.goi) {
 


### PR DESCRIPTION
Added functionality to output hybrids and clusters results in BEDPE format for downstream tools.

These are now output to `results/igv`.

Tested on viral data.

Closes #32 